### PR TITLE
Do not mention deprecated Typst Preview VS Code Plugin

### DIFF
--- a/docs/chinese.md
+++ b/docs/chinese.md
@@ -47,7 +47,7 @@ Typst 是可用于出版的可编程标记语言，拥有变量、函数与包�
 ### 如何使用 VS Code 进行本地编辑？
 
 1. 在 [VS Code](https://code.visualstudio.com/) 中打开任意工作目录。
-2. 在 VS Code 中安装 [Tinymist Typst](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist) 和 [Typst Preview](https://marketplace.visualstudio.com/items?itemName=mgt19937.typst-preview) 插件。前者负责语法高亮和错误检查等功能，后者负责预览。
+2. 在 VS Code 中安装 [Tinymist Typst](https://marketplace.visualstudio.com/items?itemName=myriad-dreamin.tinymist) 插件，其提供了语法高亮、错误检查和预览等功能。
     - 也推荐下载 [Typst Companion](https://marketplace.visualstudio.com/items?itemName=CalebFiggers.typst-companion) 插件，其提供了例如 `Ctrl + B` 进行加粗等便捷的快捷键。
     - 你还可以下载我开发的 [Typst Sync](https://marketplace.visualstudio.com/items?itemName=OrangeX4.vscode-typst-sync) 和 [Typst Sympy Calculator](https://marketplace.visualstudio.com/items?itemName=OrangeX4.vscode-typst-sympy-calculator) 插件，前者提供了本地包的云同步功能，后者提供了基于 Typst 语法的科学计算器功能。
 3. 新建一个 `test.typ` 文件，写入内容 `= Hello World`。


### PR DESCRIPTION
According to https://github.com/Enter-tainer/typst-preview/pull/305, the project has been merged into tinymist, and users are encouraged to migrate to tinymist.